### PR TITLE
At temp DB libs

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,6 +14,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libffi-dev \
 		libgdbm5 \
 		libgdbm-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev-compat \
+		#remove once on cimg/base:2020.06 or later
+		libpq-dev \
 		libncurses5-dev \
 		libreadline6-dev \
 		libssl-dev \


### PR DESCRIPTION
These are being installed in cimg/base. Once this image uses
cimg/base:2020.06 or later, this PR can be reverted.

Closes #35.