### PR TITLE
Respin latest release for last 3 series.

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.03
+FROM cimg/base:2020.05
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -14,6 +14,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libffi-dev \
 		libgdbm5 \
 		libgdbm-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev-compat \
+		#remove once on cimg/base:2020.06 or later
+		libpq-dev \
 		libncurses5-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/2.5/node/Dockerfile
+++ b/2.5/node/Dockerfile
@@ -4,14 +4,12 @@ FROM cimg/ruby:2.5.8
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-# Version hardcoded for now in this repo. Eventually once:
-# https://github.com/CircleCI-Public/cimg-node/issues/16 is completed, this
 # Dockerfile will pull the latest LTS release from cimg-node.
-ENV NODE_VERSION 12.16.1
-
-RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
 	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
-	rm node.tar.xz && \
+	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 1.22.4

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.03
+FROM cimg/base:2020.05
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -14,6 +14,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libffi-dev \
 		libgdbm5 \
 		libgdbm-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev-compat \
+		#remove once on cimg/base:2020.06 or later
+		libpq-dev \
 		libncurses5-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/2.6/node/Dockerfile
+++ b/2.6/node/Dockerfile
@@ -4,14 +4,12 @@ FROM cimg/ruby:2.6.6
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-# Version hardcoded for now in this repo. Eventually once:
-# https://github.com/CircleCI-Public/cimg-node/issues/16 is completed, this
 # Dockerfile will pull the latest LTS release from cimg-node.
-ENV NODE_VERSION 12.16.1
-
-RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
 	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
-	rm node.tar.xz && \
+	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 1.22.4

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.03
+FROM cimg/base:2020.05
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -14,6 +14,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libffi-dev \
 		libgdbm5 \
 		libgdbm-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev \
+		#remove once on cimg/base:2020.06 or later
+		libmariadb-dev-compat \
+		#remove once on cimg/base:2020.06 or later
+		libpq-dev \
 		libncurses5-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/2.7/node/Dockerfile
+++ b/2.7/node/Dockerfile
@@ -4,14 +4,12 @@ FROM cimg/ruby:2.7.1
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-# Version hardcoded for now in this repo. Eventually once:
-# https://github.com/CircleCI-Public/cimg-node/issues/16 is completed, this
 # Dockerfile will pull the latest LTS release from cimg-node.
-ENV NODE_VERSION 12.16.1
-
-RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
 	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
-	rm node.tar.xz && \
+	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 1.22.4

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
+docker build --file 2.5/Dockerfile -t cimg/ruby:2.5.8  -t cimg/ruby:2.5 .
+docker build --file 2.5/node/Dockerfile -t cimg/ruby:2.5.8-node  -t cimg/ruby:2.5-node .
+docker build --file 2.6/Dockerfile -t cimg/ruby:2.6.6  -t cimg/ruby:2.6 .
+docker build --file 2.6/node/Dockerfile -t cimg/ruby:2.6.6-node  -t cimg/ruby:2.6-node .
 docker build --file 2.7/Dockerfile -t cimg/ruby:2.7.1  -t cimg/ruby:2.7 .
 docker build --file 2.7/node/Dockerfile -t cimg/ruby:2.7.1-node  -t cimg/ruby:2.7-node .


### PR DESCRIPTION
Respining to add important DB libraries before this image goes GA. Not
including the v2.4.x series due to it becoming EOL days after these
releases.