### PR TITLE
Publish v2.6.2 and v2.7.2. [release]

### DIFF
--- a/2.6/node/Dockerfile
+++ b/2.6/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:2.6.6
+FROM cimg/ruby:2.6.2
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,10 +1,10 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.05
+FROM cimg/base:2020.09
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV RUBY_VERSION=2.7.1 \
+ENV RUBY_VERSION=2.7.2 \
 	RUBY_MAJOR=2.7
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
@@ -12,20 +12,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		bison \
 		dpkg-dev \
 		libffi-dev \
-		libgdbm5 \
+		libgdbm6 \
 		libgdbm-dev \
-		#remove once on cimg/base:2020.06 or later
-		libmariadb-dev \
-		#remove once on cimg/base:2020.06 or later
-		libmariadb-dev-compat \
-		#remove once on cimg/base:2020.06 or later
-		libpq-dev \
 		libncurses5-dev \
 		libreadline6-dev \
 		libssl-dev \
 		libyaml-dev \
-		#remove once on cimg/base:2020.06 or later
-		tzdata \
 		zlib1g-dev && \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \

--- a/2.7/node/Dockerfile
+++ b/2.7/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:2.7.1
+FROM cimg/ruby:2.7.2
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -12,7 +12,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		bison \
 		dpkg-dev \
 		libffi-dev \
-		libgdbm5 \
+		libgdbm6 \
 		libgdbm-dev \
 		libncurses5-dev \
 		libreadline6-dev \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-docker build --file 2.5/Dockerfile -t cimg/ruby:2.5.8  -t cimg/ruby:2.5 .
-docker build --file 2.5/node/Dockerfile -t cimg/ruby:2.5.8-node  -t cimg/ruby:2.5-node .
-docker build --file 2.6/Dockerfile -t cimg/ruby:2.6.6  -t cimg/ruby:2.6 .
-docker build --file 2.6/node/Dockerfile -t cimg/ruby:2.6.6-node  -t cimg/ruby:2.6-node .
-docker build --file 2.7/Dockerfile -t cimg/ruby:2.7.1  -t cimg/ruby:2.7 .
-docker build --file 2.7/node/Dockerfile -t cimg/ruby:2.7.1-node  -t cimg/ruby:2.7-node .
+docker build --file 2.6/node/Dockerfile -t cimg/ruby:2.6.2-node .
+
+docker build --file 2.7/Dockerfile -t cimg/ruby:2.7.2  -t cimg/ruby:2.7 .
+docker build --file 2.7/node/Dockerfile -t cimg/ruby:2.7.2-node  -t cimg/ruby:2.7-node .


### PR DESCRIPTION
Closes #46.

Ruby v2.6.2 was already released by us. At the time, the Node variant didn't exists. So this PR releases a normal Ruby v2.7.2 release but also specifically and **only** releases a Ruby v2.6.2 Node variant. The regular Ruby v2.6.2 image is untouched.