### PR TITLE
Add `--enable-shared`, `--build` and `--disable-install-doc` flags

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.05
+FROM cimg/base:2020.12
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -12,20 +12,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		bison \
 		dpkg-dev \
 		libffi-dev \
-		libgdbm5 \
+		libgdbm6 \
 		libgdbm-dev \
-		#remove once on cimg/base:2020.06 or later
-		libmariadb-dev \
-		#remove once on cimg/base:2020.06 or later
-		libmariadb-dev-compat \
-		#remove once on cimg/base:2020.06 or later
-		libpq-dev \
 		libncurses5-dev \
 		libreadline6-dev \
 		libssl-dev \
 		libyaml-dev \
-		#remove once on cimg/base:2020.06 or later
-		tzdata \
 		zlib1g-dev && \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \
@@ -34,7 +26,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure && \
+	./configure --disable-install-doc --enable-shared --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \

--- a/2.5/node/Dockerfile
+++ b/2.5/node/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/maste
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.4
+ENV YARN_VERSION 1.22.5
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.05
+FROM cimg/base:2020.12
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -12,20 +12,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		bison \
 		dpkg-dev \
 		libffi-dev \
-		libgdbm5 \
+		libgdbm6 \
 		libgdbm-dev \
-		#remove once on cimg/base:2020.06 or later
-		libmariadb-dev \
-		#remove once on cimg/base:2020.06 or later
-		libmariadb-dev-compat \
-		#remove once on cimg/base:2020.06 or later
-		libpq-dev \
 		libncurses5-dev \
 		libreadline6-dev \
 		libssl-dev \
 		libyaml-dev \
-		#remove once on cimg/base:2020.06 or later
-		tzdata \
 		zlib1g-dev && \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \
@@ -34,7 +26,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure && \
+	./configure --disable-install-doc --enable-shared --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \

--- a/2.6/node/Dockerfile
+++ b/2.6/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:2.6.2
+FROM cimg/ruby:2.6.6
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/maste
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.4
+ENV YARN_VERSION 1.22.5
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.09
+FROM cimg/base:2020.12
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -26,7 +26,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure && \
+	./configure --disable-install-doc --enable-shared --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \

--- a/2.7/node/Dockerfile
+++ b/2.7/node/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/maste
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.4
+ENV YARN_VERSION 1.22.5
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -26,7 +26,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure && \
+	./configure --disable-install-doc --enable-shared --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,7 +26,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure && \
+	./configure --disable-install-doc --enable-shared --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,3 +3,12 @@
 docker build --file 3.0/Dockerfile -t cimg/ruby:3.0.0  -t cimg/ruby:3.0 .
 docker build --file 3.0/node/Dockerfile -t cimg/ruby:3.0.0-node  -t cimg/ruby:3.0-node .
 docker build --file 3.0/browsers/Dockerfile -t cimg/ruby:3.0.0-browsers  -t cimg/ruby:3.0-browsers .
+docker build --file 2.7/Dockerfile -t cimg/ruby:2.7.2  -t cimg/ruby:2.7 .
+docker build --file 2.7/node/Dockerfile -t cimg/ruby:2.7.2-node  -t cimg/ruby:2.7-node .
+docker build --file 2.7/browsers/Dockerfile -t cimg/ruby:2.7.2-browsers  -t cimg/ruby:2.7-browsers .
+docker build --file 2.6/Dockerfile -t cimg/ruby:2.6.6  -t cimg/ruby:2.6 .
+docker build --file 2.6/node/Dockerfile -t cimg/ruby:2.6.6-node  -t cimg/ruby:2.6-node .
+docker build --file 2.6/browsers/Dockerfile -t cimg/ruby:2.6.6-browsers  -t cimg/ruby:2.6-browsers .
+docker build --file 2.5/Dockerfile -t cimg/ruby:2.5.8  -t cimg/ruby:2.5 .
+docker build --file 2.5/node/Dockerfile -t cimg/ruby:2.5.8-node  -t cimg/ruby:2.5-node .
+docker build --file 2.5/browsers/Dockerfile -t cimg/ruby:2.5.8-browsers  -t cimg/ruby:2.5-browsers .


### PR DESCRIPTION
This PR replicates the [flags used in the base docker-ruby image](https://github.com/docker-library/ruby/blob/1d3efccb4b5fc99cb7ae15ca9ba3ad7b56b7709b/Dockerfile-debian.template#L51). Most importantly for us is the `--enable-shared` flag, since we use some gems which rely on it. `--disable-install-doc` should be helpful as well since it will reduce the image size.