### PR TITLE
Pre-install Rails Deps [release]

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2021.04
+FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -11,14 +11,38 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		autoconf \
 		bison \
 		dpkg-dev \
+		# Rails dep
+		ffmpeg \
+		# until the base image has it
+		libcurl4-openssl-dev \
 		libffi-dev \
 		libgdbm6 \
 		libgdbm-dev \
+		# Rails dep
+		libmysqlclient-dev \
 		libncurses5-dev \
+		# Rails dep
+		libpq-dev \
 		libreadline6-dev \
+		# install libsqlite3-dev until the base image has it
+		# Rails dep
+		libsqlite3-dev \
 		libssl-dev \
+		# Rails dep
+		libxml2-dev \
 		libyaml-dev \
-		zlib1g-dev && \
+		# Rails dep
+		memcached \
+		# Rails dep
+		mupdf \
+		# Rails dep
+		mupdf-tools \
+		# Rails dep
+		imagemagick \
+		# Rails dep
+		sqlite3 \
+		zlib1g-dev \
+	&& \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \
 	mkdir -p ~/ruby && \
@@ -41,4 +65,3 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 ENV GEM_HOME /home/circleci/.rubygems
 ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
-

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,14 +11,38 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		autoconf \
 		bison \
 		dpkg-dev \
+		# Rails dep
+		ffmpeg \
+		# until the base image has it
+		libcurl4-openssl-dev \
 		libffi-dev \
 		libgdbm6 \
 		libgdbm-dev \
+		# Rails dep
+		libmysqlclient-dev \
 		libncurses5-dev \
+		# Rails dep
+		libpq-dev \
 		libreadline6-dev \
+		# install libsqlite3-dev until the base image has it
+		# Rails dep
+		libsqlite3-dev \
 		libssl-dev \
+		# Rails dep
+		libxml2-dev \
 		libyaml-dev \
-		zlib1g-dev && \
+		# Rails dep
+		memcached \
+		# Rails dep
+		mupdf \
+		# Rails dep
+		mupdf-tools \
+		# Rails dep
+		imagemagick \
+		# Rails dep
+		sqlite3 \
+		zlib1g-dev \
+	&& \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \
 	mkdir -p ~/ruby && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,9 +3,3 @@
 docker build --file 3.0/Dockerfile -t cimg/ruby:3.0.2  -t cimg/ruby:3.0 .
 docker build --file 3.0/node/Dockerfile -t cimg/ruby:3.0.2-node  -t cimg/ruby:3.0-node .
 docker build --file 3.0/browsers/Dockerfile -t cimg/ruby:3.0.2-browsers  -t cimg/ruby:3.0-browsers .
-docker build --file 2.7/Dockerfile -t cimg/ruby:2.7.4  -t cimg/ruby:2.7 .
-docker build --file 2.7/node/Dockerfile -t cimg/ruby:2.7.4-node  -t cimg/ruby:2.7-node .
-docker build --file 2.7/browsers/Dockerfile -t cimg/ruby:2.7.4-browsers  -t cimg/ruby:2.7-browsers .
-docker build --file 2.6/Dockerfile -t cimg/ruby:2.6.8  -t cimg/ruby:2.6 .
-docker build --file 2.6/node/Dockerfile -t cimg/ruby:2.6.8-node  -t cimg/ruby:2.6-node .
-docker build --file 2.6/browsers/Dockerfile -t cimg/ruby:2.6.8-browsers  -t cimg/ruby:2.6-browsers .


### PR DESCRIPTION
This includes a re-spin of Ruby v3.0.2 due to legacy image migration needs.

The image will get package changes, which is minor. It will also get an update from Node.js v14 to v16 in the process. If someone needs to stick with Node.js v14, they will need to do it manually, such as with the [Node.js Orb](https://circleci.com/developer/orbs/orb/circleci/node).

Closes #63
Closes #64
Closes #71