### PR TITLE
Publish v3.1.1.

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -1,10 +1,12 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2021.10
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV RUBY_VERSION=3.1.0 \
+ENV RUBY_VERSION=3.1.1 \
 	RUBY_MAJOR=3.1
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/3.1/browsers/Dockerfile
+++ b/3.1/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:3.1.0-node
+FROM cimg/ruby:3.1.1-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/3.1/node/Dockerfile
+++ b/3.1/node/Dockerfile
@@ -1,11 +1,11 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:3.1.0
+FROM cimg/ruby:3.1.1
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Dockerfile will pull the latest LTS release from cimg-node.
-RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
 	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
 	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
 	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
+# Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 3.1/Dockerfile -t cimg/ruby:3.1.0  -t cimg/ruby:3.1 .
-docker build --file 3.1/node/Dockerfile -t cimg/ruby:3.1.0-node  -t cimg/ruby:3.1-node .
-docker build --file 3.1/browsers/Dockerfile -t cimg/ruby:3.1.0-browsers  -t cimg/ruby:3.1-browsers .
+docker build --file 3.1/Dockerfile -t cimg/ruby:3.1.1  -t cimg/ruby:3.1 .
+docker build --file 3.1/node/Dockerfile -t cimg/ruby:3.1.1-node  -t cimg/ruby:3.1-node .
+docker build --file 3.1/browsers/Dockerfile -t cimg/ruby:3.1.1-browsers  -t cimg/ruby:3.1-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Do not edit by hand; please use build scripts/templates to make changes
+
+docker push cimg/ruby:3.1.1
+docker push cimg/ruby:3.1
+docker push cimg/ruby:3.1.1-node
+docker push cimg/ruby:3.1-node
+docker push cimg/ruby:3.1.1-browsers
+docker push cimg/ruby:3.1-browsers


### PR DESCRIPTION
ruby-3.1.1 is released on https://www.ruby-lang.org/en/news/2022/02/18/ruby-3-1-1-released/

After this change, I ran following:

```console
$ ./build-images.sh
...
Removing intermediate container 6da5a47108bb
 ---> ff0db03587b1
Successfully built ff0db03587b1
Successfully tagged cimg/ruby:3.1.1-browsers
Successfully tagged cimg/ruby:3.1-browsers
$ echo $?
0
$ docker run -it cimg/ruby:3.1.1 ruby -v
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux]
$ docker run -it cimg/ruby:3.1.1-node ruby -v
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux]
$ docker run -it cimg/ruby:3.1.1-browsers ruby -v
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux]
```
