### PR TITLE
Add --allow-releaseinfo-change flag to apt-get update

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 ENV RUBY_VERSION=2.6.9 \
 	RUBY_MAJOR=2.6
 
-RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+RUN sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y --no-install-recommends \
 		autoconf \
 		bison \
 		dpkg-dev \


### PR DESCRIPTION
Packages like `libpq-dev` and `pkg-config` aren't installing correctly for us, requiring us to add a step in our workflow:
```yml
- run:
    name: Install dependencies
    command: |
      sudo apt-get update --allow-releaseinfo-change \
        && sudo apt-get install --no-install-recommends -y \
          cmake \
          libpq-dev \
          pkg-config \
          tzdata \
```

Without the `--allow-releaseinfo-change` the install fails due to a 404. It is likely caused by bullseye being released in August 2021. The issue is explained [here](https://superuser.com/a/1457007).