### PR TITLE
Compile Ruby with --enable-shared flag

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -52,7 +52,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure && \
+	./configure --enable-shared && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \


### PR DESCRIPTION
This is [what official Ruby images do](https://github.com/docker-library/ruby/blob/c60bce99f6fddc64c926d09f68ab577aa7ff2f7e/3.1/buster/Dockerfile#L59), so it might make sense for images that might be used for builds also do.

This would fix #79.