### PR TITLE
Enable YJIT support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -48,6 +48,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		# Rails dep
 		sqlite3 \
 		zlib1g-dev \
+		# YJIT dep
+		rustc \
 	&& \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \
@@ -56,7 +58,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --enable-shared && \
+	./configure --enable-yjit --enable-shared && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
@@ -67,7 +69,10 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	gem --version && \
 	sudo gem update --system && \
 	gem --version && \
-	bundle --version
+	bundle --version && \
+
+	# Cleanup YJIT install deps
+	sudo apt-get remove rustc && sudo apt-get autoremove
 
 ENV GEM_HOME /home/circleci/.rubygems
 ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH


### PR DESCRIPTION
Enable YJIT support in the Ruby compile. This does not enable it by default, but just adds the option for users who would like to use it. This is included in the default Ruby image.

To build support for YJIT we have to install Rust for the Ruby build, but to keep the image size down we remove Rust and its dependancies after the build has completed. 

https://shopify.engineering/ruby-yjit-is-production-ready

Closes #108 