### PR TITLE
Add clang-14 for installing gems with Rust extensions

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -50,6 +50,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		zlib1g-dev \
 		# YJIT dep
 		rustc \
+		# Build gems with Rust extensions dep
+		clang-14 \
 	&& \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -50,8 +50,6 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		zlib1g-dev \
 		# YJIT dep
 		rustc \
-		# Build gems with Rust extensions dep
-		clang-14 \
 	&& \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -51,6 +51,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		zlib1g-dev \
 		# YJIT dep
 		rustc \
+    # Build gems with Rust extensions dep
+		clang-14 \
 	&& \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \


### PR DESCRIPTION
Add clang-14 dependency for installing gems with Rust extensions such as https://github.com/HarlemSquirrel/tzf-rb