### PR TITLE
Add Arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.3
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.3
+  cimg: circleci/cimg@0.3.4
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 
@@ -23,6 +23,7 @@ workflows:
     jobs:
       - cimg/build-and-deploy:
           name: "Staging"
+          resource-class: 2xlarge+
           docker-namespace: ccitest
           docker-repository: ruby
           publish-branch: test
@@ -39,6 +40,7 @@ workflows:
           context: cimg-publishing
       - cimg/build-and-deploy:
           name: "Deploy"
+          resource-class: 2xlarge+
           docker-repository: ruby
           filters:
             branches:

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,6 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-# NOTE: Ruby under 3.1 require OpenSSL >= 1.0.1, < 3.0.0, so use Ubuntu 20.04.
 FROM cimg/%%PARENT%%:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
@@ -53,17 +52,20 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		rustc \
     	# Build gems with Rust extensions dep
 		clang-14 && \
-	# For Ruby 3.0 install OpenSSL 1.1.1g to make it work on Ubuntu 20.04
+	# For Ruby 3.0 install OpenSSL 1.1.1 to make it work on Ubuntu 20.04
 	if [ "${RUBY_MAJOR}" == "3.0" ]; then \
-		wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz; \
-		tar zxvf openssl-1.1.1g.tar.gz; \
-		cd openssl-1.1.1g; \
-		./config --prefix=$HOME/.openssl/openssl-1.1.1g --openssldir=$HOME/.openssl/openssl-1.1.1g; \
-		make && make test && make install; \
-		rm -rf ~/.openssl/openssl-1.1.1g/certs; \
-		ln -s /etc/ssl/certs ~/.openssl/openssl-1.1.1g/certs; \
-		cd .. && rm -rf openssl-1.1.1g; \
-		RUBY_CONFIGURE_OPTS=--with-openssl-dir=$HOME/.openssl/openssl-1.1.1g; \
+		if [[ $(uname -m) == "x86_64" ]]; then \
+			wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2_amd64.deb; \
+			wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2_amd64.deb; \
+			wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb; \
+		else \
+			wget http://ports.ubuntu.com/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2_arm64.deb; \
+			wget http://ports.ubuntu.com/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2_arm64.deb; \
+			wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb; \
+		fi && \
+		sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2*.deb; \
+		sudo dpkg -i libssl-dev_1.1.1f-1ubuntu2*.deb; \
+		sudo dpkg -i openssl_1.1.1f-1ubuntu2*.deb; \
 	fi && \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -72,7 +72,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --enable-yjit --enable-shared && \
+	./configure --enable-yjit --enable-shared --disable-install-doc && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
@@ -81,7 +81,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 	ruby --version && \
 	gem --version && \
-	sudo gem update --system && \
+	MAKEFLAGS=-j"$(nproc)" sudo gem update --system && \
 	gem --version && \
 	bundle --version && \
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,7 +7,7 @@
 # October.
 
 # NOTE: Ruby under 3.1 require OpenSSL >= 1.0.1, < 3.0.0, so use Ubuntu 20.04.
-FROM cimg/%%PARENT%%:2023.04-20.04
+FROM cimg/%%PARENT%%:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -51,9 +51,20 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		zlib1g-dev \
 		# YJIT dep
 		rustc \
-    # Build gems with Rust extensions dep
-		clang-14 \
-	&& \
+    	# Build gems with Rust extensions dep
+		clang-14 && \
+	# For Ruby 3.0 install OpenSSL 1.1.1g to make it work on Ubuntu 20.04
+	if [ "${RUBY_MAJOR}" == "3.0" ]; then \
+		wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz; \
+		tar zxvf openssl-1.1.1g.tar.gz; \
+		cd openssl-1.1.1g; \
+		./config --prefix=$HOME/.openssl/openssl-1.1.1g --openssldir=$HOME/.openssl/openssl-1.1.1g; \
+		make && make test && make install; \
+		rm -rf ~/.openssl/openssl-1.1.1g/certs; \
+		ln -s /etc/ssl/certs ~/.openssl/openssl-1.1.1g/certs; \
+		cd .. && rm -rf openssl-1.1.1g; \
+		RUBY_CONFIGURE_OPTS=--with-openssl-dir=$HOME/.openssl/openssl-1.1.1g; \
+	fi && \
 	# Skip installing gem docs
 	echo "gem: --no-document" > ~/.gemrc && \
 	mkdir -p ~/ruby && \

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=ruby
 parent=base
 variants=(node browsers)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
Add arm64 support via buildx

# Reasons

This PR also includes a workaround to the openssl issue for Ruby 3.0. We can install the openssl 1.1.1 packages from 20.04 and they appear to work without issue. This means we no longer need to rely on a 20.04 base image for Ruby 3.0 images

Test builds completed successfully: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-ruby/561/workflows/e18ce16c-3c99-49ee-95f5-6937a6d8a51e/jobs/679

Note: building ruby images with buildx is slow, therefore I have disabled the docs generation which was causing a huge issue.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
