### PR TITLE
refactor: cimg build sign and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,9 @@ workflows:
     when:
       not: << pipeline.parameters.cron >>
     jobs:
-      - cimg-build-and-deploy:
-          name: "Build and Deploy"
+      - cimg-build:
+          name: "Build and Stage"
+          resource-class: 2xlarge+
           docker-namespace: ccitest
           docker-repository: ruby
           filters:
@@ -37,6 +38,14 @@ workflows:
                 event: pass
                 mentions: "@jalexchen"
                 template: basic_success_1
+      - cimg-deploy:
+          name: "Deploy"
+          filters:
+            branches:
+              only:
+                - main
+          context: cimg-publishing
+          post-steps:
             - slack/notify:
                 branch_pattern: main
                 event: fail
@@ -85,17 +94,33 @@ jobs:
             sudo chmod +x rubyFeed.sh
             git submodule update --init --recursive
             ./rubyFeed.sh
-  cimg-build-and-deploy:
+  cimg-build:
     docker:
-      - image: cimg/aws:2023.09.1
+      - image: cimg/base:current
     parameters:
       docker-namespace:
         type: string
       docker-repository:
         type: string
+      resource-class:
+        type: string
     steps:
       - checkout
       - setup_remote_docker
+      - cimg/build-images:
+          docker-namespace: <<parameters.docker-namespace>>
+          docker-repository: <<parameters.docker-repository>>
+  cimg-deploy:
+    docker:
+      - image: cimg/aws:2023.09.1
+    steps:
+      - checkout
+      - run:
+          name: Halt if not release
+          command: |
+            if ! git log -1 --pretty=%s | grep "\[release\]; then
+              circleci step halt
+            fi
       - aws-cli/setup:
           region: ${AWS_DEFAULT_REGION}
           role_arn: arn:aws:iam::483285841698:role/cpe-images-bucket-write
@@ -110,14 +135,6 @@ jobs:
           region: ${AWS_DEFAULT_REGION}
           role_arn: arn:aws:iam::483285841698:role/cpe-kms-sign
           role_session_name: "sign-docker-images"
-      - when:
-          condition:
-            not:
-              equal: [ main, <<pipeline.git.branch>> ]
-          steps:
-          - cimg/build-images:
-              docker-namespace: <<parameters.docker-namespace>>
-              docker-repository: <<parameters.docker-repository>>
       - run:
           name: Install Cosign
           command: |
@@ -134,4 +151,4 @@ jobs:
           command: |
             echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
             git submodule update --init --recursive
-            ./shared/build-and-deploy.sh run "$CIRCLE_BRANCH" "$S3_BUCKET_NAME"
+            ./shared/build-and-deploy.sh run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   cimg: circleci/cimg@0.3.4
+  aws-cli: circleci/aws-cli@4.1.0
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 
@@ -21,38 +22,26 @@ workflows:
     when:
       not: << pipeline.parameters.cron >>
     jobs:
-      - cimg/build-and-deploy:
-          name: "Staging"
-          resource-class: 2xlarge+
+      - cimg-build-and-deploy:
+          name: "Build and Deploy"
           docker-namespace: ccitest
           docker-repository: ruby
-          publish-branch: test
           filters:
             branches:
               ignore:
                 - main
+          context: cimg-publishing
           post-steps:
             - slack/notify:
                 branch_pattern: release-v.+
                 event: pass
                 mentions: "@jalexchen"
                 template: basic_success_1
-          context: cimg-publishing
-      - cimg/build-and-deploy:
-          name: "Deploy"
-          resource-class: 2xlarge+
-          docker-repository: ruby
-          filters:
-            branches:
-              only:
-                - main
-          post-steps:
             - slack/notify:
                 branch_pattern: main
                 event: fail
                 mentions: "@images"
                 template: basic_fail_1
-          context: cimg-publishing
 
 jobs:
   check-feed:
@@ -96,3 +85,53 @@ jobs:
             sudo chmod +x rubyFeed.sh
             git submodule update --init --recursive
             ./rubyFeed.sh
+  cimg-build-and-deploy:
+    docker:
+      - image: cimg/aws:2023.09.1
+    parameters:
+      docker-namespace:
+        type: string
+      docker-repository:
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker
+      - aws-cli/setup:
+          region: ${AWS_DEFAULT_REGION}
+          role_arn: arn:aws:iam::483285841698:role/cpe-images-bucket-write
+          role_session_name: "write-to-s3"
+          profile_name: "s3write"
+      - aws-cli/setup:
+          region: ${AWS_DEFAULT_REGION}
+          role_arn: arn:aws:iam::483285841698:role/cpe-images-bucket-read
+          role_session_name: "read-from-s3"
+          profile_name: "s3read"
+      - aws-cli/setup:
+          region: ${AWS_DEFAULT_REGION}
+          role_arn: arn:aws:iam::483285841698:role/cpe-kms-sign
+          role_session_name: "sign-docker-images"
+      - when:
+          condition:
+            not:
+              equal: [ main, <<pipeline.git.branch>> ]
+          steps:
+          - cimg/build-images:
+              docker-namespace: <<parameters.docker-namespace>>
+              docker-repository: <<parameters.docker-repository>>
+      - run:
+          name: Install Cosign
+          command: |
+            url="https://github.com/sigstore/cosign/releases/latest/download/cosign-linux"
+            [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64"
+
+            if ! cosign version &> /dev/null; then
+              curl -O -L "$url-$ARCH" >cosign && \
+              sudo chmod 755 cosign
+              sudo cp cosign /usr/local/bin/
+            fi
+      - run:
+          name: Sign, Verify, Deploy
+          command: |
+            echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
+            git submodule update --init --recursive
+            ./shared/build-and-deploy.sh run "$CIRCLE_BRANCH" "$S3_BUCKET_NAME"


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

Description
A brief description of the changes in this PR.
PR for new docker image workflow, which enables signing, verification, and reduction in build/deploy time.

Reasons
Please provide reasoning for these changes and how this PR achieves them.
builds once to staging, then calls the submodule to sign, copy, and verify images in the production dockerhub when deployed

If applicable, include a link to the related GitHub issue that this PR will close.

Checklist
Please check through the following before opening your PR. Thank you!

- [no] I have made changes to the Dockerfile.template file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)