### PR TITLE
docs: update the image and orb version to the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ For example:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7.2
+      - image: cimg/ruby:3.2.2
     steps:
       - checkout
       - run: ruby --version
 ```
 
 In the above example, the CircleCI Ruby Docker image is used for the primary container.
-More specifically, the tag `2.7.2` is used meaning the version of Ruby will be Ruby v2.7.2.
+More specifically, the tag `3.2.2` is used meaning the version of Ruby will be Ruby v3.2.2.
 You can now use Ruby within the steps for this job.
 
 ## How This Image Works
@@ -65,7 +65,7 @@ The Node.js variant can be used by appending `-node` to the end of an existing `
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7-node
+      - image: cimg/ruby:3.2-node
     steps:
       - checkout
       - run: ruby --version
@@ -81,11 +81,11 @@ You can use the orb to install a version of Google Chrome and/or Firefox into yo
 
 ```yaml
 orbs:
-  browser-tools: circleci/browser-tools@1.1
+  browser-tools: circleci/browser-tools@1.4.6
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7-browsers
+      - image: cimg/ruby:3.2-browsers
     steps:
       - browser-tools/install-browser-tools
       - checkout


### PR DESCRIPTION
# Description

Replaces the old notation with the EOL'd version of Ruby (2.7) with the latest version (3.2) as well as updating `circleci/browser-tools` orb to the latest.

# Reasons

With the current version of `circleci/browser-tools` orb (1.1), users can use only Chrome 112 while the latest version of it is 118 as of writing.

# Checklist

Please check through the following before opening your PR. Thank you!

- [n/a] I have made changes to the `Dockerfile.template` file only
- [n/a] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](https://github.com/CircleCI-Public/cimg-ruby/blob/main/.github/CONTRIBUTING.md)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
