### PR TITLE
chore: update cimg-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.6.0
+  cimg: circleci/cimg@0.6.1
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Update cimg-orb version

# Reasons
To allow releases of new ruby cimgs
