### PR TITLE
Delete jemalloc flag in template dockerfile

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -77,7 +77,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --with-jemalloc --enable-yjit --enable-shared --disable-install-doc && \
+	./configure --enable-yjit --enable-shared --disable-install-doc && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
@@ -91,7 +91,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	bundle --version && \
 
 	# Cleanup YJIT install deps
-	sudo apt-get remove rustc libstd-rust* libjemalloc-dev
+	sudo apt-get remove rustc libstd-rust*
 
 ENV GEM_HOME /home/circleci/.rubygems
 ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
This flag is not present in any other Dockerfiles and prevents compiling gems using native extensions (e.g. bcrypt, pg, etc). It looks like it was introduced in https://github.com/CircleCI-Public/cimg-ruby/pull/139 (possibly without an image being built). Opting to delete just flag, but a followup PR is probably needed to cleanup or fix the remainder. As it stands the 3.3 images aren't able to install gems with native extensions (e.g. `pg`, `nokogiri`, `bcrypt`, etc).

### Before
```
gem install bcrypt
```

```
Fetching bcrypt-3.1.20.gem
Building native extensions. This could take a while...
ERROR:  Error installing bcrypt:
	ERROR: Failed to build gem native extension.

    current directory: /home/circleci/.rubygems/gems/bcrypt-3.1.20/ext/mri
/usr/local/bin/ruby extconf.rb
creating Makefile

current directory: /home/circleci/.rubygems/gems/bcrypt-3.1.20/ext/mri
make DESTDIR\= sitearchdir\=./.gem.20240102-13-aa2evc sitelibdir\=./.gem.20240102-13-aa2evc clean

current directory: /home/circleci/.rubygems/gems/bcrypt-3.1.20/ext/mri
make DESTDIR\= sitearchdir\=./.gem.20240102-13-aa2evc sitelibdir\=./.gem.20240102-13-aa2evc
compiling bcrypt_ext.c
In file included from /usr/local/include/ruby-3.3.0/ruby/internal/config.h:22,
                 from /usr/local/include/ruby-3.3.0/ruby/ruby.h:15,
                 from /usr/local/include/ruby-3.3.0/ruby.h:38,
                 from bcrypt_ext.c:1:
/usr/local/include/ruby-3.3.0/x86_64-linux/ruby/config.h:82:40: fatal error: jemalloc/jemalloc.h: No such file or directory
   82 | #define RUBY_ALTERNATIVE_MALLOC_HEADER <jemalloc/jemalloc.h>
      |                                        ^
compilation terminated.
make: *** [Makefile:248: bcrypt_ext.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/circleci/.rubygems/gems/bcrypt-3.1.20 for inspection.
Results logged to /home/circleci/.rubygems/extensions/x86_64-linux/3.3.0/bcrypt-3.1.20/gem_make.out
```

### After

```
gem install bcrypt
```

```
Fetching bcrypt-3.1.20.gem
Building native extensions. This could take a while...
Successfully installed bcrypt-3.1.20
1 gem installed
```

# Reasons
https://github.com/CircleCI-Public/cimg-ruby/issues/155

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
