### PR TITLE
Publish v3.3.0. [release]

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -6,9 +6,9 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/base:2024.01
+FROM cimg/base:2023.07
 
-LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 
 ENV RUBY_VERSION=3.3.0 \
 	RUBY_MAJOR=3.3
@@ -77,7 +77,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --with-jemalloc --enable-yjit --enable-shared --disable-install-doc && \
+	./configure --enable-yjit --enable-shared --disable-install-doc && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
@@ -91,7 +91,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	bundle --version && \
 
 	# Cleanup YJIT install deps
-	sudo apt-get remove rustc libstd-rust* libjemalloc-dev
+	sudo apt-get remove rustc libstd-rust*
 
 ENV GEM_HOME /home/circleci/.rubygems
 ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -6,9 +6,9 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/base:2023.07
+FROM cimg/base:2024.01
 
-LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 ENV RUBY_VERSION=3.3.0 \
 	RUBY_MAJOR=3.3

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2023.07
+FROM cimg/%%PARENT%%:2024.01
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 


### PR DESCRIPTION
Publish v3.3.0. [release] This is a re-release of 3.3.0 removing jemalloc as the default malloc implementation, but keeping it on the image for users to access as they want