### PR TITLE
Create and publish Ruby@3.3.1

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -10,7 +10,7 @@ FROM cimg/base:2024.01
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV RUBY_VERSION=3.3.0 \
+ENV RUBY_VERSION=3.3.1 \
 	RUBY_MAJOR=3.3
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/3.3/browsers/Dockerfile
+++ b/3.3/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:3.3.0-node
+FROM cimg/ruby:3.3.1-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/3.3/node/Dockerfile
+++ b/3.3/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:3.3.0
+FROM cimg/ruby:3.3.1
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(3.2.3)
+GEN_CHECK=(3.3.1)

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 
 docker context create cimg
 docker buildx create --use cimg
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.2/Dockerfile -t cimg/ruby:3.2.3 -t cimg/ruby:3.2 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.2/node/Dockerfile -t cimg/ruby:3.2.3-node -t cimg/ruby:3.2-node --push .
-docker buildx build --platform=linux/amd64 --file 3.2/browsers/Dockerfile -t cimg/ruby:3.2.3-browsers -t cimg/ruby:3.2-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 3.3/Dockerfile -t cimg/ruby:3.3.1 -t cimg/ruby:3.2 --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 3.3/node/Dockerfile -t cimg/ruby:3.3.1-node -t cimg/ruby:3.3.1-node --push .
+docker buildx build --platform=linux/amd64 --file 3.3/browsers/Dockerfile -t cimg/ruby:3.3.1-browsers -t cimg/ruby:3.3.1-browsers --push .


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Fixes #165

I want to get cimg/ruby:3.3.1 sooner than later, since this is open sourced, I'd like to help out. 
Perhaps this doesn't work so feel free to close the PR.

I mostly follow PR #153 in generating the version 3.3.0.

# Reasons
There's a security bug in Ruby 3.3.0 detailed in the issue https://github.com/CircleCI-Public/cimg-ruby/issues/165. I'd like to get the updated build since our app build need to match the CI build ruby version.

If applicable, include a link to the related GitHub issue that this PR will close.
https://github.com/CircleCI-Public/cimg-ruby/issues/165

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
