### PR TITLE
Update rubyFeed regex to allow for v prefix of releases

### DIFF
--- a/rubyFeed.sh
+++ b/rubyFeed.sh
@@ -11,7 +11,7 @@ fi
 
 getRubyVersion() {
   RSS_URL="https://github.com/ruby/ruby/tags.atom"
-  VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
+  VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>[v?]*//' -e 's/<\/title>//')
 
   for version in $VERSIONS; do
     if [[ $version =~ ^[0-9]+(\_[0-9]+)*$ || $version =~ ^[0-9]+(\.[0-9]+)*$ ]]; then


### PR DESCRIPTION
# Description

Update the `rubyFeed` regex to allow for v prefix of releases

# Reasons

As flagged by @miyucy in https://github.com/CircleCI-Public/cimg-ruby/issues/174 the latest Ruby release is listed as `v3.3.3`.

The current regex:

```sh
curl --silent "https://github.com/ruby/ruby/tags.atom" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//'

v3.3.3
3.3.2
3.1.6
3.4.0-preview1
3.3.1
3.2.4
3.1.5
3.0.7
3.2.3
3.3.0
```

With the added `[v?]*` to the regex the version list now looks like:

```sh
curl --silent "https://github.com/ruby/ruby/tags.atom" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>[v?]*//' -e 's/<\/title>//'
3.3.3
3.3.2
3.1.6
3.4.0-preview1
3.3.1
3.2.4
3.1.5
3.0.7
3.2.3
3.3.0
```
