### PR TITLE
Publish v3.4.1. [release]

### DIFF
--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -6,12 +6,12 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2024.12
+FROM cimg/base:2024.12
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 
-ENV RUBY_VERSION=%%VERSION_FULL%% \
-	RUBY_MAJOR=%%VERSION_MINOR%%
+ENV RUBY_VERSION=3.4.1 \
+	RUBY_MAJOR=3.4
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		autoconf \

--- a/3.4/browsers/Dockerfile
+++ b/3.4/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/ruby:3.4.1-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+	sudo apt-get install --yes --no-install-recommends \
+		xvfb \
+	&& \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+# Install a single version of Firefox. This isn't intended to be a regularly
+# updated thing. Instead, if this version of Firefox isn't what the end user
+# wants they should install a different version via the Browser Tools Orb.
+#
+# Canonical made a major technology change in how Firefox is installed from
+# Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
+# based Firefox right now so we are installing it from the Mozilla PPA.
+RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 1001' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	sudo add-apt-repository --yes ppa:mozillateam/ppa && \
+	sudo apt-get install --no-install-recommends --yes firefox && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	firefox --version
+
+# Install a single version of Google Chrome Stable. This isn't intended to be a
+# regularly updated thing. Instead, if this version of Chrome isn't what the
+# end user wants they should install a different version via the Browser Tools
+# Orb.
+RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
+	echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
+	sudo apt-get update && \
+	sudo apt-get install google-chrome-stable && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/3.4/node/Dockerfile
+++ b/3.4/node/Dockerfile
@@ -1,0 +1,21 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/ruby:3.4.1
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="arm64" && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.19
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(3.3.6)
+GEN_CHECK=(3.4.1)

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 
 docker context create cimg
 docker buildx create --use cimg
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.3/Dockerfile -t cimg/ruby:3.3.6 -t cimg/ruby:3.3 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.3/node/Dockerfile -t cimg/ruby:3.3.6-node -t cimg/ruby:3.3-node --push .
-docker buildx build --platform=linux/amd64 --file 3.3/browsers/Dockerfile -t cimg/ruby:3.3.6-browsers -t cimg/ruby:3.3-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 3.4/Dockerfile -t cimg/ruby:3.4.1 -t cimg/ruby:3.4 --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 3.4/node/Dockerfile -t cimg/ruby:3.4.1-node -t cimg/ruby:3.4-node --push .
+docker buildx build --platform=linux/amd64 --file 3.4/browsers/Dockerfile -t cimg/ruby:3.4.1-browsers -t cimg/ruby:3.4-browsers --push .


### PR DESCRIPTION
There's already a ["Publish v3.4.1 and v3.4.0" PR](https://github.com/CircleCI-Public/cimg-ruby/pull/188) from `cpe-image-bot`, but it's failing.

I think it's failing because Ruby had [a version string mixup](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-1-released/) with `v3.4.0` and because [ccitest/ruby doesn't have](https://hub.docker.com/r/ccitest/ruby/tags) a `3.4.0` tag, only `3.4.1`.

This PR adds just Ruby 3.4.1, by updating `Dockerfile.template` from `2024.02` to `2024.12` and then running `./shared/gen-dockerfiles.sh 3.4.1`.

With those changes I'm able to successfully run `docker build` with the new Dockerfiles locally.

----------

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
