### PR TITLE
Fix some Dockerfile warnings

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -83,15 +83,14 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	mkdir ~/.rubygems && \
 	sudo rm -rf ~/ruby /var/lib/apt/lists/* && \
 	cd && \
-
+	# Check that installs succeeded
 	ruby --version && \
 	gem --version && \
 	MAKEFLAGS=-j"$(nproc)" sudo gem update --system && \
 	gem --version && \
 	bundle --version && \
-
 	# Cleanup YJIT install deps
 	sudo apt-get remove rustc libstd-rust*
 
-ENV GEM_HOME /home/circleci/.rubygems
-ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+ENV GEM_HOME=/home/circleci/.rubygems
+ENV PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH


### PR DESCRIPTION
Same types of things as in https://github.com/CircleCI-Public/cimg-shared/pull/101.

Warnings emitted by Docker:
- NoEmptyContinuation: Empty continuation line (line 94)
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 96)
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 97)

----------

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
