### PR TITLE
Release v4.0.3

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=UndefinedVar
 # vim:set ft=dockerfile:
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -10,7 +10,7 @@ FROM cimg/base:2026.03
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 
-ENV RUBY_VERSION=4.0.2 \
+ENV RUBY_VERSION=4.0.3 \
 	RUBY_MAJOR=4.0
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
@@ -34,6 +34,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		# Rails dep
 		libsqlite3-dev \
 		libssl-dev \
+		# Rails dep
+		libvips \
 		# Rails dep
 		libxml2-dev \
 		libyaml-dev \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -14,6 +14,7 @@ ENV RUBY_VERSION=4.0.3 \
 	RUBY_MAJOR=4.0
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		autoconf \
 		bison \
 		dpkg-dev \
 		# Rails dep
@@ -77,6 +78,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	downloadURL="https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-$RUBY_VERSION.tar.gz" && \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
+	autoconf && \
 	./configure --enable-yjit --enable-shared --disable-install-doc && \
 	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
 	make -j "$(( $(nproc) / 2 + 1 ))" && \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -96,4 +96,4 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo apt-get remove rustc libstd-rust*
 
 ENV GEM_HOME=/home/circleci/.rubygems
-ENV PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+ENV PATH=$GEM_HOME/bin:${BUNDLE_PATH:+$BUNDLE_PATH/bin:}$PATH

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -53,9 +53,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		# YJIT dep
 		rustc \
 		# Jemalloc
-		libjemalloc-dev \
-    	# Build gems with Rust extensions dep
-		clang-14 && \
+		libjemalloc-dev && \
 	# For Ruby 3.0 install OpenSSL 1.1.1 to make it work on Ubuntu 20.04
 	if [ "${RUBY_MAJOR}" == "3.0" ]; then \
 		if [[ $(uname -m) == "x86_64" ]]; then \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -14,7 +14,6 @@ ENV RUBY_VERSION=4.0.3 \
 	RUBY_MAJOR=4.0
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-		autoconf \
 		bison \
 		dpkg-dev \
 		# Rails dep
@@ -78,7 +77,6 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	downloadURL="https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-$RUBY_VERSION.tar.gz" && \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
-	autoconf && \
 	./configure --enable-yjit --enable-shared --disable-install-doc && \
 	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
 	make -j "$(( $(nproc) / 2 + 1 ))" && \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -89,7 +89,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	# Check that installs succeeded
 	ruby --version && \
 	gem --version && \
-	MAKEFLAGS=-j"$(( $(nproc) / 2 + 1 ))" sudo gem update --system && \
+	MAKEFLAGS=-j"$(nproc)" sudo gem update --system && \
 	gem --version && \
 	bundle --version && \
 	# Cleanup YJIT install deps

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -80,7 +80,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	cd ~/ruby && \
 	autoconf && \
 	./configure --enable-yjit --enable-shared --disable-install-doc && \
-	make -j "$(nproc)" && \
+	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
+	make -j "$(( $(nproc) / 2 + 1 ))" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
 	sudo rm -rf ~/ruby /var/lib/apt/lists/* && \
@@ -88,7 +89,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	# Check that installs succeeded
 	ruby --version && \
 	gem --version && \
-	MAKEFLAGS=-j"$(nproc)" sudo gem update --system && \
+	MAKEFLAGS=-j"$(( $(nproc) / 2 + 1 ))" sudo gem update --system && \
 	gem --version && \
 	bundle --version && \
 	# Cleanup YJIT install deps

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -84,8 +84,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		ac_cv_header_sys_times_h=yes \
 		ac_cv_type_ssize_t=yes \
 		ac_cv_sizeof_ssize_t=8 && \
-	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
-	make -j "$(( $(nproc) / 2 + 1 ))" && \
+	# Cap parallelism: QEMU arm64 emulation segfaults with too many gcc jobs
+	make -j 4 && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
 	sudo rm -rf ~/ruby /var/lib/apt/lists/* && \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -78,7 +78,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --enable-yjit --enable-shared --disable-install-doc && \
+	# Force known-good values for probes that flake under QEMU arm64 emulation
+	./configure --enable-yjit --enable-shared --disable-install-doc \
+		ac_cv_header_sys_resource_h=yes \
+		ac_cv_header_sys_times_h=yes \
+		ac_cv_type_ssize_t=yes \
+		ac_cv_sizeof_ssize_t=8 && \
 	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
 	make -j "$(( $(nproc) / 2 + 1 ))" && \
 	sudo make install && \

--- a/4.0/browsers/Dockerfile
+++ b/4.0/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:4.0.2-node
+FROM cimg/ruby:4.0.3-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/4.0/node/Dockerfile
+++ b/4.0/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:4.0.2
+FROM cimg/ruby:4.0.3
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,3 +1,4 @@
+# check=skip=UndefinedVar
 # vim:set ft=dockerfile:
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,7 +14,6 @@ ENV RUBY_VERSION=%%VERSION_FULL%% \
 	RUBY_MAJOR=%%VERSION_MINOR%%
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-		autoconf \
 		bison \
 		dpkg-dev \
 		# Rails dep
@@ -78,7 +77,6 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	downloadURL="https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-$RUBY_VERSION.tar.gz" && \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
-	autoconf && \
 	./configure --enable-yjit --enable-shared --disable-install-doc && \
 	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
 	make -j "$(( $(nproc) / 2 + 1 ))" && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,6 +14,7 @@ ENV RUBY_VERSION=%%VERSION_FULL%% \
 	RUBY_MAJOR=%%VERSION_MINOR%%
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		autoconf \
 		bison \
 		dpkg-dev \
 		# Rails dep
@@ -77,6 +78,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	downloadURL="https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-$RUBY_VERSION.tar.gz" && \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
+	autoconf && \
 	./configure --enable-yjit --enable-shared --disable-install-doc && \
 	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
 	make -j "$(( $(nproc) / 2 + 1 ))" && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -95,4 +95,4 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo apt-get remove rustc libstd-rust*
 
 ENV GEM_HOME=/home/circleci/.rubygems
-ENV PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+ENV PATH=$GEM_HOME/bin:${BUNDLE_PATH:+$BUNDLE_PATH/bin:}$PATH

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -53,9 +53,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		# YJIT dep
 		rustc \
 		# Jemalloc
-		libjemalloc-dev \
-    	# Build gems with Rust extensions dep
-		clang-14 && \
+		libjemalloc-dev && \
 	# For Ruby 3.0 install OpenSSL 1.1.1 to make it work on Ubuntu 20.04
 	if [ "${RUBY_MAJOR}" == "3.0" ]; then \
 		if [[ $(uname -m) == "x86_64" ]]; then \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -89,7 +89,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	# Check that installs succeeded
 	ruby --version && \
 	gem --version && \
-	MAKEFLAGS=-j"$(( $(nproc) / 2 + 1 ))" sudo gem update --system && \
+	MAKEFLAGS=-j"$(nproc)" sudo gem update --system && \
 	gem --version && \
 	bundle --version && \
 	# Cleanup YJIT install deps

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -80,7 +80,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	cd ~/ruby && \
 	autoconf && \
 	./configure --enable-yjit --enable-shared --disable-install-doc && \
-	make -j "$(nproc)" && \
+	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
+	make -j "$(( $(nproc) / 2 + 1 ))" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
 	sudo rm -rf ~/ruby /var/lib/apt/lists/* && \
@@ -88,7 +89,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	# Check that installs succeeded
 	ruby --version && \
 	gem --version && \
-	MAKEFLAGS=-j"$(nproc)" sudo gem update --system && \
+	MAKEFLAGS=-j"$(( $(nproc) / 2 + 1 ))" sudo gem update --system && \
 	gem --version && \
 	bundle --version && \
 	# Cleanup YJIT install deps

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -84,8 +84,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		ac_cv_header_sys_times_h=yes \
 		ac_cv_type_ssize_t=yes \
 		ac_cv_sizeof_ssize_t=8 && \
-	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
-	make -j "$(( $(nproc) / 2 + 1 ))" && \
+	# Cap parallelism: QEMU arm64 emulation segfaults with too many gcc jobs
+	make -j 4 && \
 	sudo make install && \
 	mkdir ~/.rubygems && \
 	sudo rm -rf ~/ruby /var/lib/apt/lists/* && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -78,7 +78,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --enable-yjit --enable-shared --disable-install-doc && \
+	# Force known-good values for probes that flake under QEMU arm64 emulation
+	./configure --enable-yjit --enable-shared --disable-install-doc \
+		ac_cv_header_sys_resource_h=yes \
+		ac_cv_header_sys_times_h=yes \
+		ac_cv_type_ssize_t=yes \
+		ac_cv_sizeof_ssize_t=8 && \
 	# Halve parallelism: full nproc causes OOM under QEMU arm64 emulation
 	make -j "$(( $(nproc) / 2 + 1 ))" && \
 	sudo make install && \

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(3.2.11)
+GEN_CHECK=(4.0.3)

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 
 docker context create cimg
 docker buildx create --use cimg
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.2/Dockerfile -t cimg/ruby:3.2.11 -t cimg/ruby:3.2 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.2/node/Dockerfile -t cimg/ruby:3.2.11-node -t cimg/ruby:3.2-node --push .
-docker buildx build --platform=linux/amd64 --file 3.2/browsers/Dockerfile -t cimg/ruby:3.2.11-browsers -t cimg/ruby:3.2-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 4.0/Dockerfile -t cimg/ruby:4.0.3 -t cimg/ruby:4.0 --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 4.0/node/Dockerfile -t cimg/ruby:4.0.3-node -t cimg/ruby:4.0-node --push .
+docker buildx build --platform=linux/amd64 --file 4.0/browsers/Dockerfile -t cimg/ruby:4.0.3-browsers -t cimg/ruby:4.0-browsers --push .


### PR DESCRIPTION
# Description

Fix arm64 build failure for Ruby 4.0.3 image. The build crashed with `gcc: internal compiler error: Segmentation fault` during compilation under QEMU emulation, and the generated `4.0/Dockerfile` had a stale `$BUNDLE_PATH` reference.

Also autoconf probes randomly crash under QEMU arm64 emulation, causing `./configure` to misdetect headers and types. Each build fails on a different probe (`sys/resource.h`, `ssize_t`). Passing `ac_cv_*` cache variables forces known-good values, skipping the flaky probes entirely. But waiting for passing CI.

Closes: https://github.com/CircleCI-Public/cimg-ruby/pull/226

# Reasons

`make -j "$(nproc)"` launched 32 parallel gcc processes on the arm64 QEMU builder, exhausting memory. Halving parallelism with `$(( $(nproc) / 2 + 1 ))` prevents OOM while keeping builds fast. ~~A follow-up PR will switch to native arm64 executors if you are ok with this ?~~

The `4.0/Dockerfile` still referenced `$BUNDLE_PATH` unconditionally after the template was fixed in 1ae3f4d, triggering a BuildKit `UndefinedVar` warning. Propagated the `${BUNDLE_PATH:+$BUNDLE_PATH/bin:}` conditional expansion.

# Checklist

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
```

I really hop it will help to have more frequent up-to-date cimg-ruby images.