### PR TITLE
ci: skip release when branch already exists on remote

### DIFF
--- a/rubyFeed.sh
+++ b/rubyFeed.sh
@@ -19,7 +19,11 @@ getRubyVersion() {
       generateSearchTerms "RUBY_VERSION=" "$majorMinor/Dockerfile" "\\"
       directoryCheck "$majorMinor" "$SEARCH_TERM"
       if [[ $(eval echo $?) == 0 ]]; then
-        generateVersionString "$newVersion"
+        if git ls-remote --exit-code --heads origin "release-v${newVersion}" > /dev/null 2>&1; then
+          echo "Branch release-v${newVersion} already exists on remote, skipping"
+        else
+          generateVersionString "$newVersion"
+        fi
       fi
     fi
   done


### PR DESCRIPTION
# Description

Prevent rubyFeed.sh from failing when re-running after a release branch was already pushed. Check `git ls-remote` before adding a version to the release list.

# Reasons

It's noise?

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
