### PR TITLE
Fix Ruby 4.0.3 QEMU build: migrate CircleCI config to cimg-go style [release]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.6.4
-  slack: circleci/slack@4.12.1
+  cimg: circleci/cimg@0.6.5
+  slack: circleci/slack@4.13.3
 
 parameters:
   cron:
@@ -23,16 +23,13 @@ workflows:
     when:
       not: << pipeline.parameters.cron >>
     jobs:
-      - cimg/build-and-deploy:
+      - build_and_deploy:
           name: "Test"
-          resource-class: 2xlarge+
-          docker-namespace: ccitest
-          docker-repository: ruby
           filters:
             branches:
               ignore:
                 - main
-          context: 
+          context:
             - slack-notification-access-token
             - slack-cimg-notifications
             - cimg-docker-image-building
@@ -42,10 +39,8 @@ workflows:
                 event: fail
                 mentions: "@images"
                 template: basic_fail_1
-      - cimg/build-and-deploy:
+      - build_and_deploy:
           name: "Deploy"
-          resource-class: 2xlarge+
-          docker-repository: ruby
           filters:
             branches:
               only:
@@ -61,3 +56,60 @@ workflows:
                 event: fail
                 mentions: "@images"
                 template: basic_fail_1
+
+jobs:
+  build_and_deploy:
+    machine:
+      image: ubuntu-2404:current
+    resource_class: 2xlarge+
+    steps:
+      - run:
+          name: Install latest QEMU
+          command: sudo apt-get update && sudo apt-get install qemu-system
+      - run:
+          name: Register binfmt for supported platforms
+          command: docker run --privileged --rm tonistiigi/binfmt --install all
+      - checkout
+      - run:
+          name: Docker login
+          command: echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin
+      - when:
+          condition:
+            not:
+              equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: "Build and deploy to ccitest/ruby"
+                command: |
+                  DOCKER_NAMESPACE="ccitest"
+                  source ./manifest
+
+                  while IFS= read -r line; do
+
+                  if [[ $arm64 == "1" ]]; then
+                    directory=$(echo "$line" | awk '{print $6}')
+                  else
+                    directory=$(echo "$line" | awk '{print $4}')
+                  fi
+                  if [[ "${directory}" =~ "Dockerfile" ]]; then
+                    if [ "${parent:?}" != "base" ]; then
+                      sed -i "s|cimg/${repository:?}|${DOCKER_NAMESPACE}/${repository}|g" "$directory"
+                      sed -i "s|cimg/${parent}|${DOCKER_NAMESPACE}/${parent}|g" "$directory"
+                    else
+                      sed -i "s|cimg/$repository|${DOCKER_NAMESPACE}/${repository}|g" "$directory"
+                    fi
+                  fi
+
+                  done < ./build-images.sh
+
+                  sed 's|cimg|'"${DOCKER_NAMESPACE}"'|g' ./build-images.sh > ./build-images-stage.sh
+
+                  chmod +x ./build-images-stage.sh
+                  ./build-images-stage.sh
+      - when:
+          condition:
+            equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: "Build and deploy to cimg/ruby"
+                command: ./build-images.sh

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -10,7 +10,7 @@ FROM cimg/base:2026.03
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 
-ENV RUBY_VERSION=4.0.2 \
+ENV RUBY_VERSION=4.0.3 \
 	RUBY_MAJOR=4.0
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
@@ -35,6 +35,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		# Rails dep
+		libvips \
+		# Rails dep
 		libxml2-dev \
 		libyaml-dev \
 		# Rails dep
@@ -51,9 +53,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		# YJIT dep
 		rustc \
 		# Jemalloc
-		libjemalloc-dev \
-    	# Build gems with Rust extensions dep
-		clang-14 && \
+		libjemalloc-dev && \
 	# For Ruby 3.0 install OpenSSL 1.1.1 to make it work on Ubuntu 20.04
 	if [ "${RUBY_MAJOR}" == "3.0" ]; then \
 		if [[ $(uname -m) == "x86_64" ]]; then \
@@ -77,7 +77,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --enable-yjit --enable-shared --disable-install-doc && \
+	# Force known-good values for probes that flake under QEMU arm64 emulation
+	./configure --enable-yjit --enable-shared --disable-install-doc \
+		ac_cv_header_sys_resource_h=yes \
+		ac_cv_header_sys_times_h=yes \
+		ac_cv_type_ssize_t=yes \
+		ac_cv_sizeof_ssize_t=8 && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=UndefinedVar
 # vim:set ft=dockerfile:
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
@@ -98,4 +99,4 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo apt-get remove rustc libstd-rust*
 
 ENV GEM_HOME=/home/circleci/.rubygems
-ENV PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+ENV PATH=$GEM_HOME/bin:${BUNDLE_PATH:+$BUNDLE_PATH/bin:}$PATH

--- a/4.0/browsers/Dockerfile
+++ b/4.0/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:4.0.2-node
+FROM cimg/ruby:4.0.3-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/4.0/node/Dockerfile
+++ b/4.0/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/ruby:4.0.2
+FROM cimg/ruby:4.0.3
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -53,9 +53,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		# YJIT dep
 		rustc \
 		# Jemalloc
-		libjemalloc-dev \
-    	# Build gems with Rust extensions dep
-		clang-14 && \
+		libjemalloc-dev && \
 	# For Ruby 3.0 install OpenSSL 1.1.1 to make it work on Ubuntu 20.04
 	if [ "${RUBY_MAJOR}" == "3.0" ]; then \
 		if [[ $(uname -m) == "x86_64" ]]; then \
@@ -79,7 +77,12 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL $downloadURL | tar -xz -C ~/ruby --strip-components=1 && \
 	cd ~/ruby && \
 	autoconf && \
-	./configure --enable-yjit --enable-shared --disable-install-doc && \
+	# Force known-good values for probes that flake under QEMU arm64 emulation
+	./configure --enable-yjit --enable-shared --disable-install-doc \
+		ac_cv_header_sys_resource_h=yes \
+		ac_cv_header_sys_times_h=yes \
+		ac_cv_type_ssize_t=yes \
+		ac_cv_sizeof_ssize_t=8 && \
 	make -j "$(nproc)" && \
 	sudo make install && \
 	mkdir ~/.rubygems && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,3 +1,4 @@
+# check=skip=UndefinedVar
 # vim:set ft=dockerfile:
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
@@ -98,4 +99,4 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo apt-get remove rustc libstd-rust*
 
 ENV GEM_HOME=/home/circleci/.rubygems
-ENV PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+ENV PATH=$GEM_HOME/bin:${BUNDLE_PATH:+$BUNDLE_PATH/bin:}$PATH

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(3.2.11)
+GEN_CHECK=(4.0.3)

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 
 docker context create cimg
 docker buildx create --use cimg
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.2/Dockerfile -t cimg/ruby:3.2.11 -t cimg/ruby:3.2 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 3.2/node/Dockerfile -t cimg/ruby:3.2.11-node -t cimg/ruby:3.2-node --push .
-docker buildx build --platform=linux/amd64 --file 3.2/browsers/Dockerfile -t cimg/ruby:3.2.11-browsers -t cimg/ruby:3.2-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 4.0/Dockerfile -t cimg/ruby:4.0.3 -t cimg/ruby:4.0 --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 4.0/node/Dockerfile -t cimg/ruby:4.0.3-node -t cimg/ruby:4.0-node --push .
+docker buildx build --platform=linux/amd64 --file 4.0/browsers/Dockerfile -t cimg/ruby:4.0.3-browsers -t cimg/ruby:4.0-browsers --push .


### PR DESCRIPTION
# Description

Same as #228 but with a build inspired by https://github.com/CircleCI-Public/cimg-go/blob/main/.circleci/config.yml to avoid the issue with QEMU and arm build that segfault most of the time. Maybe cimg orb should migrate to `tonistiigi/binfmt` instead of https://github.com/multiarch/qemu-user-static/releases that is no longer maintain.

# Reasons

Too frequent build failures (segfault) with Quemu and ARM.

```
1073.8 compiling ./main.c
1073.8 compiling dmydln.c
1074.5 compiling miniinit.c
1074.6 making dummy probes.h
1074.6 compiling ast.c
1074.7 compiling bignum.c
1074.7 Segmentation fault (core dumped)
1074.7 compiling box.c
1074.7 make: *** [Makefile:500: miniinit.o] Error 139
1074.7 make: *** Waiting for unfinished jobs....
```
https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-ruby/2131/workflows/acd640a0-ba13-4459-b4fb-a9e5b1e4e156/jobs/2280

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only 🔴 
- [ ] I have not made any manual changes to automatically generated files, I'm following cimg-go si I think it's ok.
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
