### PR TITLE
fix: Remove noise in rubyfeed bash script run

### DIFF
--- a/rubyFeed.sh
+++ b/rubyFeed.sh
@@ -16,7 +16,7 @@ getRubyVersion() {
   for version in $VERSIONS; do
     if [[ $version =~ ^[0-9]+(\_[0-9]+)*$ || $version =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
       generateVersions "$(echo "$version" | trimmer "v" | sed -r 's/_/./g')"
-      generateSearchTerms "RUBY_VERSION=" "$majorMinor/Dockerfile" "\\"
+      generateSearchTerms "RUBY_VERSION=" "$majorMinor/Dockerfile" "\\\\"
       directoryCheck "$majorMinor" "$SEARCH_TERM"
       if [[ $(eval echo $?) == 0 ]]; then
         if git ls-remote --exit-code --heads origin "release-v${newVersion}" > /dev/null 2>&1; then


### PR DESCRIPTION
# Description

Remove noise in rubyfeed script runs.

# Reason

GNU tr warns about unescaped trailing backslashes. Double the escaping so `tr -d` receives `\\` instead of bare `\`.

See: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-ruby/2146/workflows/e387697d-025f-4065-9b4a-0c398289e759/jobs/2295

```
^@^@Submodule 'shared' (git@github.com:CircleCI-Public/cimg-shared.git) registered for path 'shared' Cloning into '/home/circleci/project/shared'...
Submodule path 'shared': checked out 'd95e2f20b03dd5549065ac1cf2513f79b4e37ac9' tr: warning: an unescaped backslash at end of string is not portable directory 4.0 exists; checking for matching versions: 4.0.3 Parsed version 4.0.3 is not greater than 4.0.3
tr: warning: an unescaped backslash at end of string is not portable directory 3.3 exists; checking for matching versions: 3.3.11 Parsed version 3.3.11 is not greater than 3.3.11
tr: warning: an unescaped backslash at end of string is not portable directory 3.2 exists; checking for matching versions: 3.2.11 Parsed version 3.2.11 is not greater than 3.2.11
tr: warning: an unescaped backslash at end of string is not portable directory 4.0 exists; checking for matching versions: 4.0.3 Parsed version 4.0.2 is not greater than 4.0.3
tr: warning: an unescaped backslash at end of string is not portable directory 3.4 exists; checking for matching versions: 3.4.9 Parsed version 3.4.9 is not greater than 3.4.9
tr: warning: an unescaped backslash at end of string is not portable directory 3.2 exists; checking for matching versions: 3.2.11 Parsed version 3.2.10 is not greater than 3.2.11
tr: warning: an unescaped backslash at end of string is not portable directory 4.0 exists; checking for matching versions: 4.0.3 Parsed version 4.0.1 is not greater than 4.0.3
tr: warning: an unescaped backslash at end of string is not portable directory 4.0 exists; checking for matching versions: 4.0.3 Parsed version 4.0.0 is not greater than 4.0.3
tr: warning: an unescaped backslash at end of string is not portable directory 3.4 exists; checking for matching versions: 3.4.9 Parsed version 3.4.8 is not greater than 3.4.9
No new version updates

```

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
